### PR TITLE
fix: Use notify wrapper function in command definition

### DIFF
--- a/denops/glance/main.ts
+++ b/denops/glance/main.ts
@@ -47,17 +47,4 @@ export async function main(denops: Denops) {
       return Promise.resolve();
     },
   };
-  const script = `
-    function s:glance()
-      call denops#notify('${denops.name}', 'listen', [])
-      augroup Grance
-        autocmd!
-        autocmd TextChanged,TextChangedI,TextChangedP <buffer> call denops#notify('${denops.name}', 'update', [])
-        autocmd CursorMoved,CursorMovedI <buffer> call denops#notify('${denops.name}', 'update', [])
-        autocmd BufUnload <buffer> call denops#notify('${denops.name}', 'close', [])
-      augroup END
-    endfunction
-    command! Glance call s:glance()
-  `;
-  execute(denops, script);
 }

--- a/plugin/glance.vim
+++ b/plugin/glance.vim
@@ -3,8 +3,8 @@ if exists('g:loaded_glance') || &cp
 endif
 let g:loaded_glance = v:true
 
-let s:save_cpo = &cpo
-set cpo&vim
+let s:save_cpoptions = &cpoptions
+set cpoptions&vim
 
 function! s:notify(method, params) abort
   call denops#plugin#wait_async('glance',
@@ -23,5 +23,5 @@ endfunction
 
 command! Glance call s:glance()
 
-let &cpo = s:save_cpo
-unlet s:save_cpo
+let &cpo = s:save_cpoptions
+unlet s:save_cpoptions

--- a/plugin/glance.vim
+++ b/plugin/glance.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_glance') || &cp
+if exists('g:loaded_glance') || &compatible
   finish
 endif
 let g:loaded_glance = v:true
@@ -23,5 +23,5 @@ endfunction
 
 command! Glance call s:glance()
 
-let &cpo = s:save_cpoptions
+let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions

--- a/plugin/glance.vim
+++ b/plugin/glance.vim
@@ -1,0 +1,34 @@
+if exists('g:loaded_glance') || &cp
+  finish
+endif
+let g:loaded_glance = v:true
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! s:notify(method, args) abort
+  if exists('g:loaded_denops')
+        \ && denops#server#status() ==# 'running'
+        \ && denops#plugin#is_loaded('glance')
+    call denops#notify('glance', a:method, a:args)
+  else
+    execute 'autocmd User DenopsPluginPost:glance ++once'
+          \ printf('call denops#notify("glance", "%s", "%s")',
+          \ a:method, string(a:args))
+  endif
+endfunction
+
+function! s:glance() abort
+  call s:notify('listen', [])
+  augroup Grance
+    autocmd! * <buffer>
+    autocmd TextChanged,TextChangedI,TextChangedP <buffer> call s:notify('update', [])
+    autocmd CursorMoved,CursorMovedI <buffer> call s:notify('update', [])
+    autocmd BufUnload <buffer> call s:notify('close', [])
+  augroup END
+endfunction
+
+command! Glance call s:glance()
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/plugin/glance.vim
+++ b/plugin/glance.vim
@@ -6,16 +6,9 @@ let g:loaded_glance = v:true
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! s:notify(method, args) abort
-  if exists('g:loaded_denops')
-        \ && denops#server#status() ==# 'running'
-        \ && denops#plugin#is_loaded('glance')
-    call denops#notify('glance', a:method, a:args)
-  else
-    execute 'autocmd User DenopsPluginPost:glance ++once'
-          \ printf('call denops#notify("glance", "%s", "%s")',
-          \ a:method, string(a:args))
-  endif
+function! s:notify(method, params) abort
+  call denops#plugin#wait_async('glance',
+        \ function('denops#notify', ['glance', a:method, a:params]))
 endfunction
 
 function! s:glance() abort


### PR DESCRIPTION
It registers autocmd of calling `denops#notify()` when denops is not ready.