### PR TITLE
fix: Handle error when the file does not exist

### DIFF
--- a/denops/glance/main.ts
+++ b/denops/glance/main.ts
@@ -7,9 +7,16 @@ import { Server } from "./server.ts";
 import { MarkdownRenderer } from "./markdown.ts";
 
 export async function main(denops: Denops) {
-  async function readFile(path: string) {
+  async function readFile(path: string): Promise<Uint8Array | null> {
     const dir = await fn.expand(denops, "%:p:h") as string;
-    return Deno.readFile(join(dir, path));
+    try {
+      return await Deno.readFile(join(dir, path));
+    } catch (error: unknown) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   async function update() {

--- a/denops/glance/server.ts
+++ b/denops/glance/server.ts
@@ -3,7 +3,7 @@ import { lookup } from "https://esm.sh/mime-types@2";
 
 interface Options {
   onOpen: () => void;
-  readFile: (path: string) => Promise<Uint8Array>;
+  readFile: (path: string) => Promise<Uint8Array | null>;
   stylesheet: string;
 }
 
@@ -47,16 +47,11 @@ export class Server {
       await req.respond({ status, headers, body });
     });
 
-    app.get("/favicon.ico", async (req) => {
-      const status = 404;
-      await req.respond({ status });
-    });
-
     app.get(/^\/(.+)/, async (req) => {
-      const status = 200;
       const contentType = lookup(req.match[1]) || "text/plain";
       const headers = new Headers({ "Content-Type": contentType });
       const body = await options.readFile(req.match[1]);
+      const status = body === null ? 404 :200;
       await req.respond({ status, headers, body });
     });
 


### PR DESCRIPTION
It returns `null` and `404` if `Deno.readFile()` is failed. So `favicon.ico` was removed.