### PR TITLE
feat: on-demand initializaiton

### DIFF
--- a/denops/glance/main.ts
+++ b/denops/glance/main.ts
@@ -1,12 +1,27 @@
 import { Denops } from "https://lib.deno.dev/x/denops_std@v3/mod.ts";
-import { execute } from "https://lib.deno.dev/x/denops_std@v3/helper/mod.ts";
 import { g } from "https://lib.deno.dev/x/denops_std@v3/variable/mod.ts";
 import * as fn from "https://lib.deno.dev/x/denops_std@v3/function/mod.ts";
 import { join } from "https://lib.deno.dev/std/path/mod.ts";
 import { Server } from "./server.ts";
 import { MarkdownRenderer } from "./markdown.ts";
 
+type Options = {
+  port: number;
+  plugins: string[];
+  html: boolean;
+  breaks: boolean;
+  linkify: boolean;
+  defaultStylesheet: string;
+  stylesheet: string;
+  defaultConfigPath: string;
+  configPath: string;
+};
+
 export async function main(denops: Denops) {
+  let options: Options | undefined;
+  let renderer: MarkdownRenderer | undefined;
+  let server: Server | undefined;
+
   async function readFile(path: string): Promise<Uint8Array | null> {
     const dir = await fn.expand(denops, "%:p:h") as string;
     try {
@@ -20,37 +35,63 @@ export async function main(denops: Denops) {
   }
 
   async function update() {
+    renderer = await ensureRenderer();
+    server = await ensureServer();
     const lines = await fn.getline(denops, 1, "$");
     const content = lines.join("\n");
     const document = await renderer.render(content);
     const pos = await fn.getpos(denops, ".");
     server.send("update", { document, line: pos[1] });
   }
-  const port = (await g.get(denops, "glance#server_port", 8765))!;
-  const plugins = (await g.get(denops, "glance#markdown_plugins", []))!;
-  const html = (await g.get(denops, "glance#markdown_html", false))!;
-  const breaks = (await g.get(denops, "glance#markdown_breaks", false))!;
-  const linkify = (await g.get(denops, "glance#markdown_linkify", false))!;
-  const defaultStylesheet = `#root {margin: 50px auto; width: min(700px, 90%);}`;
-  const stylesheet = (await g.get(denops, "glance#stylesheet", defaultStylesheet))!;
-  const defaultConfigPath = new URL("./config.ts", import.meta.url).toString();
-  const configPath = (await g.get(denops, "glance#config", defaultConfigPath))!;
-  const { createMarkdownRenderer } = await import(configPath);
-  const renderer = new MarkdownRenderer();
-  await renderer.initialize({ html, breaks, linkify, plugins, createMarkdownRenderer });
-  const server = new Server({ onOpen: update, readFile, stylesheet });
+
+  async function ensureOptions() {
+    if (options) return options;
+    const defaultStylesheet = `#root {margin: 50px auto; width: min(700px, 90%);}`;
+    const defaultConfigPath = new URL("./config.ts", import.meta.url).toString();
+    options = {
+      port: await g.get(denops, "glance#server_port", 8765),
+      plugins: await g.get(denops, "glance#markdown_plugins", []),
+      html: await g.get(denops, "glance#markdown_html", false),
+      breaks: await g.get(denops, "glance#markdown_breaks", false),
+      linkify: await g.get(denops, "glance#markdown_linkify", false),
+      defaultStylesheet,
+      stylesheet: await g.get(denops, "glance#stylesheet", defaultStylesheet),
+      defaultConfigPath,
+      configPath: await g.get(denops, "glance#config", defaultConfigPath),
+    };
+    return options;
+  }
+
+  async function ensureRenderer() {
+    if (renderer) return renderer;
+    options = await ensureOptions();
+    const { createMarkdownRenderer } = await import(options.configPath);
+    renderer = new MarkdownRenderer();
+    const { html, breaks, linkify, plugins } = options;
+    await renderer.initialize({ html, breaks, linkify, plugins, createMarkdownRenderer });
+    return renderer;
+  }
+
+  async function ensureServer() {
+    if (server) return server;
+    options = await ensureOptions();
+    server = new Server({ onOpen: update, readFile, stylesheet: options.stylesheet });
+    return server;
+  }
 
   denops.dispatcher = {
     update() {
       update();
       return Promise.resolve();
     },
-    listen() {
-      server.listen({ port });
+    async listen() {
+      options = await ensureOptions();
+      server = await ensureServer();
+      server.listen({ port: options.port });
       return Promise.resolve();
     },
     close() {
-      server.close();
+      server?.close();
       return Promise.resolve();
     },
   };

--- a/denops/glance/main.ts
+++ b/denops/glance/main.ts
@@ -11,9 +11,7 @@ type Options = {
   html: boolean;
   breaks: boolean;
   linkify: boolean;
-  defaultStylesheet: string;
   stylesheet: string;
-  defaultConfigPath: string;
   configPath: string;
 };
 
@@ -46,7 +44,7 @@ export async function main(denops: Denops) {
 
   async function ensureOptions() {
     if (options) return options;
-    const defaultStylesheet = `#root {margin: 50px auto; width: min(700px, 90%);}`;
+    const defaultStylesheet = "#root {margin: 50px auto; width: min(700px, 90%);}";
     const defaultConfigPath = new URL("./config.ts", import.meta.url).toString();
     options = {
       port: await g.get(denops, "glance#server_port", 8765),
@@ -54,9 +52,7 @@ export async function main(denops: Denops) {
       html: await g.get(denops, "glance#markdown_html", false),
       breaks: await g.get(denops, "glance#markdown_breaks", false),
       linkify: await g.get(denops, "glance#markdown_linkify", false),
-      defaultStylesheet,
       stylesheet: await g.get(denops, "glance#stylesheet", defaultStylesheet),
-      defaultConfigPath,
       configPath: await g.get(denops, "glance#config", defaultConfigPath),
     };
     return options;
@@ -88,7 +84,6 @@ export async function main(denops: Denops) {
       options = await ensureOptions();
       server = await ensureServer();
       server.listen({ port: options.port });
-      return Promise.resolve();
     },
     close() {
       server?.close();

--- a/denops/glance/server.ts
+++ b/denops/glance/server.ts
@@ -51,7 +51,7 @@ export class Server {
       const contentType = lookup(req.match[1]) || "text/plain";
       const headers = new Headers({ "Content-Type": contentType });
       const body = await options.readFile(req.match[1]);
-      const status = body === null ? 404 :200;
+      const status = body === null ? 404 : 200;
       await req.respond({ status, headers, body });
     });
 


### PR DESCRIPTION
Hi, tani san. Thank you for such a nice plugin!

This PR modifies glance to start the server when :Glance is executed, not when the plugin is loeded.
I believe this is always a better behavior, but I don't mind even if the feature is enabled by an option.

I did some refactoring as well.