### PR TITLE
fix(markdown): use `npm:` instead of esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ renderer using markdown-it plugins.
 If you want to use emoji in the markdown, then you just need to append `markdown-it-emoji` to `g:glance#plugins`
 
 ```vim
-let g:glance#plugins = ['https://esm.sh/markdown-it-emoji']
+let g:glance#markdown_plugins = ['https://esm.sh/markdown-it-emoji']
 ```
 
 The renderer dynamically loads your plugin with _dynamic import_ in Deno, then it renders the buffer content with

--- a/denops/glance/markdown.ts
+++ b/denops/glance/markdown.ts
@@ -1,4 +1,4 @@
-import MarkdownIt from "https://esm.sh/markdown-it@12";
+import MarkdownIt from "npm:markdown-it@13.0.1";
 
 interface Options {
   html: boolean;


### PR DESCRIPTION
起動が遅い問題があり、その原因はどうやらesm.shのようです。
なぜか毎回ダウンロードが走るそう。
npm:を使うことで改善されます。ただし最新のDenoを使う必要があります。
