### PR TITLE
Improve the starting notification to use `helper.echo` from `denops_std` and make it optionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ glance.
 - `g:glance#server_hostname (127.0.0.1)` is a hostname to serve the previewer.
 - `g:glance#server_port (8765)` is a port number to serve the previewer.
 - `g:glance#server_open (v:true)` is a boolean value to open the previewer automatically
+- `g:glance#server_silent (v:false)` is a boolean value to notify or silent logs from the server
 - `g:glance#markdown_plugins ([])` is a list of URLs for the markdown-it plugins.
 - `g:glance#markdown_html (v:false)` is a boolean value to be enable HTML tags in markdown.
 - `g:glance#markdown_linkify (v:false)` is a boolean value to render URLs as `a` elments .

--- a/denops/glance/main.ts
+++ b/denops/glance/main.ts
@@ -2,6 +2,7 @@ import { Denops } from "https://deno.land/x/denops_std@v6.5.1/mod.ts";
 import { g, o } from "https://deno.land/x/denops_std@v6.5.1/variable/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.5.1/function/mod.ts";
 import { collect } from "https://deno.land/x/denops_std@v6.5.1/batch/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v6.5.1/helper/mod.ts";
 import { open } from "https://deno.land/x/open@v0.0.6/index.ts";
 import { memoizy } from "npm:memoizy@1.2.3";
 import { join } from "jsr:@std/path@1.0.6";
@@ -158,6 +159,10 @@ export async function main(denops: Denops) {
       server.listen({
         hostname: options.hostname,
         port: options.port,
+        onListen: (addr: Deno.NetAddr) => {
+          const message = `[glance] Server listening on http://${addr.hostname}:${addr.port}`;
+          helper.echo(denops, message);
+        },
       });
       if (options.open) {
         await open(`http://localhost:${options.port}`, {

--- a/denops/glance/main.ts
+++ b/denops/glance/main.ts
@@ -93,6 +93,7 @@ export async function main(denops: Denops) {
       hostname,
       port,
       open,
+      silent,
       markdown_plugins,
       markdown_html,
       markdown_breaks,
@@ -103,6 +104,7 @@ export async function main(denops: Denops) {
       g.get(denops, "glance#server_hostname", "127.0.0.1"),
       g.get(denops, "glance#server_port", 8765),
       g.get(denops, "glance#server_open", true),
+      g.get(denops, "glance#server_silent", false),
       g.get(denops, "glance#markdown_plugins", []),
       g.get(denops, "glance#markdown_html", false),
       g.get(denops, "glance#markdown_breaks", false),
@@ -114,6 +116,7 @@ export async function main(denops: Denops) {
       hostname,
       port,
       open,
+      silent,
       markdown_plugins,
       markdown_html,
       markdown_breaks,
@@ -160,8 +163,10 @@ export async function main(denops: Denops) {
         hostname: options.hostname,
         port: options.port,
         onListen: (addr: Deno.NetAddr) => {
-          const message = `[glance] Server listening on http://${addr.hostname}:${addr.port}`;
-          helper.echo(denops, message);
+          if (!options.silent) {
+            const message = `[glance] Server listening on http://${addr.hostname}:${addr.port}`;
+            helper.echo(denops, message);
+          }
         },
       });
       if (options.open) {

--- a/denops/glance/server.ts
+++ b/denops/glance/server.ts
@@ -66,7 +66,7 @@ export class Server {
   close() {
     this.#controller.abort();
   }
-  listen(options: Deno.ListenOptions) {
+  listen(options: Deno.ServeTcpOptions) {
     Deno.serve({ ...options, signal: this.#controller.signal }, this.#app?.fetch!);
   }
   send(type: string, payload: unknown) {


### PR DESCRIPTION
## Motivation and Context

The current implementation uses `console.log` with default `Deno.serve` to show server startup notifications.
This results in red-colored output (tested in light-based terminals), and doesn't align well with denops's best practices.

## What Changed

1. Changed the server startup notification to use `helper.echo` from `denops_std` instead of `Deno.serve`'s default logging
2. Added a new option `g:glance#server_silent` that allows users to:
   - Completely suppress the startup notification when set to `true`
   - Maintain the default notification behavior when set to `false` (or not set)

## Demo Videos

### Current Behavior

https://github.com/user-attachments/assets/823c384e-a809-4ca3-9e9e-f56ce6e00cdd

### Default Behavior with this PR

https://github.com/user-attachments/assets/c5fe6b4c-7176-47a9-8b9f-19bbe12a726c

### Completely Silenced

https://github.com/user-attachments/assets/02f71568-ff32-4247-88dc-4f09036bf4bc

I hope this PR makes vim-glance more gently (for your eyes 😆 )
